### PR TITLE
Update docker labels

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM alpine:20230329 AS pico-sdk
-LABEL org.opencontainers.image.title="Docker Pico SDK"
-LABEL org.opencontainers.image.source="https://github.com/jisbert/docker-pico-sdk"
-LABEL org.opencontainers.image.description="Dockerized environment for building C/C++ PICO SDK based applications. Targeted for GitHub Actions."
+LABEL org.opencontainers.image.title="Raspberry Pi Pico SDK Dev Container"
+LABEL org.opencontainers.image.source="https://github.com/jisbert/devcontainer-pico-sdk"
+LABEL org.opencontainers.image.description="Containerized environment for developing C/C++ Raspberry Pi Pico SDK based applications."
 ENV PICO_SDK_PATH=/pico-sdk
 ENV CMAKE_GENERATOR=Ninja
 RUN apk add --no-cache \


### PR DESCRIPTION
## Description

Docker labels are obsolete after changing the image to a dev container image.

## Changes Made

Update docker labels to reflect the new purpose of the image.

## Docker Image

gcr.io/jisbert/devcontainer-pico-sdk:v1.5.0

## Checklist

Please check the following items before submitting this PR:

- [x] The Docker image builds and runs without errors.
- [x] All existing tests pass, and new tests have been added where appropriate.
- [x] The code follows the project's coding standards and style guide.
- [x] Documentation has been updated where necessary.
