### PR TITLE
Add gzip to the container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,11 +6,12 @@ ENV PICO_SDK_PATH=/pico-sdk
 ENV CMAKE_GENERATOR=Ninja
 RUN apk add --no-cache \
   -X https://dl-cdn.alpinelinux.org/alpine/edge/testing \
-  git=2.41.0-r0 \
   cmake=3.26.4-r1 \
   cpputest=4.0-r1 \
   g++=13.1.1_git20230603-r0 \
   g++-arm-none-eabi=13.1.0-r0 \
+  git=2.41.0-r0 \
+  gzip=1.12-r1 \
   lcov=2.0-r1 \
   python3=3.11.4-r0 \
   samurai=1.2-r4


### PR DESCRIPTION
## Description

Gzip is needed for archive coverage reports.

## Changes Made

Add gzip explicitly to the list of packages.

## Testing

Build coverage reports with the new image.

## Docker Image

ghcr.io/jisbert/devcontainer-pico-sdk:v1.5.0

## Checklist

Please check the following items before submitting this PR:

- [ ] The Docker image builds and runs without errors.
- [ ] All existing tests pass, and new tests have been added where appropriate.
- [ ] The code follows the project's coding standards and style guide.
- [ ] Documentation has been updated where necessary.
