### PR TITLE
v1.5.1

### DIFF
--- a/.github/workflows/devcontainer.yml
+++ b/.github/workflows/devcontainer.yml
@@ -29,5 +29,5 @@ jobs:
         with:
           imageName: ghcr.io/${{ github.repository }}
           cacheFrom: ghcr.io/${{ github.repository }}
-          imageTag: latest,v1.5.0
+          imageTag: latest,v1.5.1
           push: always


### PR DESCRIPTION
## Description

Upgrade pico SDK to v.1.5.1.

## Changes Made

Upgraded the docker container tag. The git clone is made from the master branch so, rebuilding the image, must pull the version v1.5.1 of the SDK, which was released recently.

## Testing

I have built the docker image without using the cache. I made sure that the 6 player clock project builds using the new image.

## Docker Image

ghcr.io/jisbert/devcontainer-pico-sdk:v1.5.1

## Checklist

Please check the following items before submitting this PR:

- [x] The Docker image builds and runs without errors.
- [x] All existing tests pass, and new tests have been added where appropriate.
- [x] The code follows the project's coding standards and style guide.
- [x] Documentation has been updated where necessary.

## Additional Notes

Raspberry Pi Pico SDK version 1.5.1 [release notes](https://github.com/raspberrypi/pico-sdk/releases/tag/1.5.1).
