### PR TITLE
Install doxygen

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,7 @@ RUN apk add --no-cache \
   -X https://dl-cdn.alpinelinux.org/alpine/edge/testing \
   cmake=3.26.4-r1 \
   cpputest=4.0-r1 \
+  doxygen=1.9.7-r0 \
   g++=13.1.1_git20230603-r0 \
   g++-arm-none-eabi=13.1.0-r0 \
   git=2.41.0-r0 \


### PR DESCRIPTION
## Description

Install doxygen to enable building code documentation with de devcontainer image.

## Related Issue(s)

https://github.com/jisbert/6-player-clock/issues/20

## Changes Made

Add doxygen to the list of apk packages installed in the container Dockerfile.

## Testing

Build code documentation using the image.

## Docker Image

ghcr.io/jisbert/devcontainer-pico-sdk:v1.5.1

## Checklist

Please check the following items before submitting this PR:

- [x] The Docker image builds and runs without errors.
- [x] All existing tests pass, and new tests have been added where appropriate.
- [x] The code follows the project's coding standards and style guide.
- [x] Documentation has been updated where necessary.
